### PR TITLE
fix bedtools call so --outseq works

### DIFF
--- a/bin/barrnap
+++ b/bin/barrnap
@@ -168,7 +168,7 @@ if ($outseq) {
     print $bed join("\t", @$b),"\n";
   }
   $bed->seek(0, SEEK_END); # rewind
-  my $cmd = "bedtools getfasta -s -name+ -fo '$outseq' -fi '$fasta' -bed '".$bed->filename."'";
+  my $cmd = "bedtools getfasta -s -name -fo '$outseq' -fi '$fasta' -bed '".$bed->filename."'";
   msg("Running: $cmd");
   system($cmd);
 }


### PR DESCRIPTION
extraneous "+" in string.