### PR TITLE
Added missing dependency and mmseqs2 parameter

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -74,7 +74,7 @@ fun.ox : $(SPROT).lineages
 	#TDIR=$(shell mktemp -d)
 	mmseqs easy-linclust \
 	$< mm.$* mm.dir.$* \
-	--min-seq-id 0.9 -c 0.8 -v 2
+	--min-seq-id 0.9 -c 0.8 -v 2 --shuffle 0
 	$(CP) mm.$(*)_rep_seq.fasta $@
 
 %.seq : %.ox $(SPROT)

--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,4 @@ dependencies:
   - taxonkit
   - make
   - bats-core
+  - mmseqs2


### PR DESCRIPTION
Hello,

In this PR I have added mmseqs2 as a dependency in the environment.yml file as it was used in the Makefile.

In addition, I have added the parameter `--shuffle 0` to avoid a warning message when building the database via `barrnap --updatedb`. This warning comes because the default values of mmseqs easy-linclust are actually not compatible. Mmseqs automatically sets this parameter when it detects this. So when setting `--shuffle 0` I just mimic the default behaviour of mmseqs, removing the warning. However, if you **want mmseqs to actually shuffle the input data**, you can instead replace `--shuffle 0` with `--createdb-mode 0`. It will remove the warning, and will be able to shuffle the data before clustering.
