### PR TITLE
Output kingdom choices deterministically

### DIFF
--- a/bin/barrnap
+++ b/bin/barrnap
@@ -70,7 +70,7 @@ $lencutoff > 0 or err("Invalid --lencutoff $lencutoff");
 $reject > 0 or err("Invalid --reject cutoff $reject");
 
 exists $KINGDOM{$kingdom} or
-  err("Imvalid --kingdom '$kingdom'. Try:", values(%KINGDOM) );
+  err("Invalid --kingdom '$kingdom'. Try:", sort keys(%KINGDOM) );
 
 if ($gcode eq 'auto' or not $gcode) {
   $gcode = $GCODE{$kingdom};
@@ -769,7 +769,7 @@ sub setOptions {
     {OPT=>"updatedb", VAR=>\$updatedb, DESC=>"Update databases from internet"},
     {OPT=>"dbdir=s", VAR=>\$dbdir, DEFAULT=>$DEFAULT_DBDIR, DESC=>"Location of databases"},
     "MODE",
-    {OPT=>"kingdom=s", VAR=>\$kingdom, DEFAULT=>'bac', DESC=>"Kingdom: ".join(',', keys %KINGDOM) },
+    {OPT=>"kingdom=s", VAR=>\$kingdom, DEFAULT=>'bac', DESC=>"Kingdom: ".join(',', sort keys %KINGDOM) },
     {OPT=>"gcodes", VAR=>\$gcode, DEFAULT=>'auto', DESC=>"Genetic code table" },
     {OPT=>"legacy!", VAR=>\$legacy,  DEFAULT=>0, DESC=>"Simulate barrnap<1.0 - only --rrna)" },
     {OPT=>"rrna!",  VAR=>\$rrna, DEFAULT=>1, DESC=>"Find rRNA, disable with --no-rrna" },


### PR DESCRIPTION
The help for `--kingdom` will display values from a Perl hash as potential options. Since the order of hash values in Perl is nondeterministic, they need to be explicitly sorted to get a reproducible output. This is useful for packagers who want to generate manpages from the help output to enable reproducible builds.

This PR also fixes a small typo in the output.